### PR TITLE
Added support for components created using React.createClass and createReactClass

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "babel-types": "^6.16.0",
+    "babel-types": "^6.24.1",
     "lodash": "4.x.x",
-    "react-docgen": "^2.12.1"
+    "react-docgen": "^2.15.0"
   },
   "license": "MIT"
 }

--- a/src/index.js
+++ b/src/index.js
@@ -28,16 +28,16 @@ export default function ({types: t}) {
         const propertyName = _.get(callee, 'property.name') ? callee.property.name.toLowerCase() : null;
         const calleeName = _.get(callee, 'name') ? callee.name.toLowerCase() : null;
 
-        // Find React.createClass()
-        const hasCreateClass = (objectName === 'react' && propertyName === 'createclass');
+        // Detect `React.createClass()`
+        const hasReactCreateClass = (objectName === 'react' && propertyName === 'createclass');
 
-        // Find createReactClass()
+        // Detect `createReactClass()`
         const hasCreateReactClass = (calleeName === 'createreactclass');
 
-        // Find React class name from variable declaration
+        // Get React class name from variable declaration
         const className = _.get(path, 'parentPath.parent.declarations[0].id.name');
 
-        if (className && (hasCreateClass || hasCreateReactClass)) {
+        if (className && (hasReactCreateClass || hasCreateReactClass)) {
           injectReactDocgenInfo(className, path, state, this.file.code, t);
         }
       },

--- a/src/index.js
+++ b/src/index.js
@@ -26,18 +26,18 @@ export default function ({types: t}) {
 
         const objectName = _.get(callee, 'object.name') ? callee.object.name.toLowerCase() : null;
         const propertyName = _.get(callee, 'property.name') ? callee.property.name.toLowerCase() : null;
+        const calleeName = _.get(callee, 'name') ? callee.name.toLowerCase() : null;
 
         // Find React.createClass()
         const hasCreateClass = (objectName === 'react' && propertyName === 'createclass');
 
         // Find createReactClass()
-        const hasCreateReactClass = (propertyName === 'createreactclass');
+        const hasCreateReactClass = (calleeName === 'createreactclass');
 
-        if (hasCreateClass || hasCreateReactClass) {
-          // This is dedicated to those who do `module.exports = React.createClass()`
-          // className = class name from variable declaration || file name
-          let className = _.get(path, 'parentPath.parent.declarations[0].id.name') || path.hub.file.opts.basename;
+        // Find React class name from variable declaration
+        const className = _.get(path, 'parentPath.parent.declarations[0].id.name');
 
+        if (className && (hasCreateClass || hasCreateReactClass)) {
           injectReactDocgenInfo(className, path, state, this.file.code, t);
         }
       },

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,26 @@ export default function ({types: t}) {
         }
         injectReactDocgenInfo(className, path, state, this.file.code, t);
       },
+      'CallExpression'(path, state) {
+        const callee = path.node.callee;
+
+        const objectName = _.get(callee, 'object.name') ? callee.object.name.toLowerCase() : null;
+        const propertyName = _.get(callee, 'property.name') ? callee.property.name.toLowerCase() : null;
+
+        // Find React.createClass()
+        const hasCreateClass = (objectName === 'react' && propertyName === 'createclass');
+
+        // Find createReactClass()
+        const hasCreateReactClass = (propertyName === 'createreactclass');
+
+        if (hasCreateClass || hasCreateReactClass) {
+          // This is dedicated to those who do `module.exports = React.createClass()`
+          // className = class name from variable declaration || file name
+          let className = _.get(path, 'parentPath.parent.declarations[0].id.name') || path.hub.file.opts.basename;
+
+          injectReactDocgenInfo(className, path, state, this.file.code, t);
+        }
+      },
       'FunctionDeclaration|FunctionExpression|ArrowFunctionExpression'(path, state) {
         if(!isStatelessComponent(path)) {
           return;

--- a/test/fixtures/createReactClass/actual.js
+++ b/test/fixtures/createReactClass/actual.js
@@ -1,0 +1,35 @@
+const createReactClass = require('create-react-class');
+const { PropTypes } = React;
+
+const stylesheet = {};
+
+/**
+ * Component for displaying a container that resembles the original CSS environment for different themes
+ */
+
+const ComponentWrapper = createReactClass({
+  propTypes: {
+    /**
+     * Theme to display
+     */
+    theme: PropTypes.string
+  },
+
+  getDefaultProps() {
+    return {
+      theme: 'damask'
+    };
+  },
+
+  render() {
+    return (
+      <div className={ stylesheet[this.props.theme] }>
+        <div className={ stylesheet.container }>
+          { this.props.children }
+        </div>
+      </div>
+    );
+  }
+});
+
+module.exports = ComponentWrapper;

--- a/test/fixtures/createReactClass/expected.js
+++ b/test/fixtures/createReactClass/expected.js
@@ -1,0 +1,65 @@
+'use strict';
+
+var createReactClass = require('create-react-class');
+var _React = React,
+    PropTypes = _React.PropTypes;
+
+
+var stylesheet = {};
+
+/**
+ * Component for displaying a container that resembles the original CSS environment for different themes
+ */
+
+var ComponentWrapper = createReactClass({
+  propTypes: {
+    /**
+     * Theme to display
+     */
+    theme: PropTypes.string
+  },
+
+  getDefaultProps: function getDefaultProps() {
+    return {
+      theme: 'damask'
+    };
+  },
+  render: function render() {
+    return React.createElement(
+      'div',
+      { className: stylesheet[this.props.theme] },
+      React.createElement(
+        'div',
+        { className: stylesheet.container },
+        this.props.children
+      )
+    );
+  }
+});
+
+module.exports = ComponentWrapper;
+ComponentWrapper.__docgenInfo = {
+  'description': 'Component for displaying a container that resembles the original CSS environment for different themes',
+  'props': {
+    'theme': {
+      'type': {
+        'name': 'custom',
+        'raw': 'PropTypes.string'
+      },
+      'required': false,
+      'description': 'Theme to display',
+      'defaultValue': {
+        'value': '\'damask\'',
+        'computed': false
+      }
+    }
+  }
+};
+
+if (typeof STORYBOOK_REACT_CLASSES !== 'undefined') {
+  STORYBOOK_REACT_CLASSES['test/fixtures/createReactClass/actual.js'] = {
+    name: 'ComponentWrapper',
+    docgenInfo: ComponentWrapper.__docgenInfo,
+    path: 'test/fixtures/createReactClass/actual.js'
+  };
+}

--- a/test/fixtures/reactCreateClass/actual.js
+++ b/test/fixtures/reactCreateClass/actual.js
@@ -1,0 +1,35 @@
+const React = require('react');
+const { PropTypes } = React;
+
+const stylesheet = {};
+
+/**
+ * Component for displaying a container that resembles the original CSS environment for different themes
+ */
+
+const ComponentWrapper = React.createClass({
+  propTypes: {
+    /**
+     * Theme to display
+     */
+    theme: PropTypes.string
+  },
+
+  getDefaultProps() {
+    return {
+      theme: 'damask'
+    };
+  },
+
+  render() {
+    return (
+      <div className={ stylesheet[this.props.theme] }>
+        <div className={ stylesheet.container }>
+          { this.props.children }
+        </div>
+      </div>
+    );
+  }
+});
+
+module.exports = ComponentWrapper;

--- a/test/fixtures/reactCreateClass/expected.js
+++ b/test/fixtures/reactCreateClass/expected.js
@@ -1,0 +1,65 @@
+'use strict';
+
+var React = require('react');
+var PropTypes = React.PropTypes;
+
+
+var stylesheet = {};
+
+/**
+ * Component for displaying a container that resembles the original CSS environment for different themes
+ */
+
+var ComponentWrapper = React.createClass({
+  displayName: 'ComponentWrapper',
+
+  propTypes: {
+    /**
+     * Theme to display
+     */
+    theme: PropTypes.string
+  },
+
+  getDefaultProps: function getDefaultProps() {
+    return {
+      theme: 'damask'
+    };
+  },
+  render: function render() {
+    return React.createElement(
+      'div',
+      { className: stylesheet[this.props.theme] },
+      React.createElement(
+        'div',
+        { className: stylesheet.container },
+        this.props.children
+      )
+    );
+  }
+});
+
+module.exports = ComponentWrapper;
+ComponentWrapper.__docgenInfo = {
+  'description': 'Component for displaying a container that resembles the original CSS environment for different themes',
+  'props': {
+    'theme': {
+      'type': {
+        'name': 'string'
+      },
+      'required': false,
+      'description': 'Theme to display',
+      'defaultValue': {
+        'value': '\'damask\'',
+        'computed': false
+      }
+    }
+  }
+};
+
+if (typeof STORYBOOK_REACT_CLASSES !== 'undefined') {
+  STORYBOOK_REACT_CLASSES['test/fixtures/reactCreateClass/actual.js'] = {
+    name: 'ComponentWrapper',
+    docgenInfo: ComponentWrapper.__docgenInfo,
+    path: 'test/fixtures/reactCreateClass/actual.js'
+  };
+}


### PR DESCRIPTION
After some painful work, I managed to add support for React components created the old school way. Fixes #14 

I'm making a few assumptions to limit the scope of this fix.
1. `React.createClass` is always called with `React`. `createClass` seems a bit generic and dangerous.
2. `createReactClass` can be called by itself.
3. Any file that has either of these two function calls will be considered a React component and processed by docgen
4. If the class does not have name like `module.exports = createReactClass()`, then we assume the filename is the class name.
5. I don't check to see if `React` is from the actual React package, same goes for `createReactClass`.

This will definitely need more testing since breaking babel means we break the entire project. We can probably publish an alpha of this and include it in the next Storybook alpha and see if it breaks anything.