### PR TITLE
Allow React.createElement to be parsed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,8 +37,24 @@ export default function ({types: t}) {
         // Get React class name from variable declaration
         const className = _.get(path, 'parentPath.parent.declarations[0].id.name');
 
+        // Detect `React.createElement()`
+        const hasReactCreateElement = (objectName === 'react' && propertyName === 'createelement');
+
         if (className && (hasReactCreateClass || hasCreateReactClass)) {
           injectReactDocgenInfo(className, path, state, this.file.code, t);
+        }
+
+        if (hasReactCreateElement) {
+          const variableDeclaration = path.findParent((path) => path.isVariableDeclaration());
+          
+          if (variableDeclaration) {
+            const elementClassName = variableDeclaration.node.declarations[0].id.name;
+            if (!isExported(path, elementClassName, t)) {
+              return;
+            }
+          
+            injectReactDocgenInfo(elementClassName, path, state, this.file.code, t);
+          }
         }
       },
       'FunctionDeclaration|FunctionExpression|ArrowFunctionExpression'(path, state) {

--- a/test/fixtures/reactCreateElement/actual.js
+++ b/test/fixtures/reactCreateElement/actual.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Kitten = ({ isWide, isLong }) => React.createElement('img', { width: isWide ? '500' : '200', height: isLong ? '500' : '200', src: 'http://placekitten.com.s3.amazonaws.com/homepage-samples/200/287.jpg' });
+
+Kitten.propTypes = {
+  /** Whether the cat is wide */
+  isWide: PropTypes.bool,
+  /** Whether the cat is long */
+  isLong: PropTypes.bool
+};
+
+Kitten.defaultProps = {
+  isWide: false,
+  isLong: false
+};
+
+export default Kitten;

--- a/test/fixtures/reactCreateElement/expected.js
+++ b/test/fixtures/reactCreateElement/expected.js
@@ -1,0 +1,70 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var Kitten = function Kitten(_ref) {
+  var isWide = _ref.isWide,
+      isLong = _ref.isLong;
+  return _react2.default.createElement('img', { width: isWide ? '500' : '200', height: isLong ? '500' : '200', src: 'http://placekitten.com.s3.amazonaws.com/homepage-samples/200/287.jpg' });
+};
+
+Kitten.propTypes = {
+  /** Whether the cat is wide */
+  isWide: _propTypes2.default.bool,
+  /** Whether the cat is long */
+  isLong: _propTypes2.default.bool
+};
+
+Kitten.defaultProps = {
+  isWide: false,
+  isLong: false
+};
+
+exports.default = Kitten;
+Kitten.__docgenInfo = {
+  'description': '',
+  'props': {
+    'isWide': {
+      'type': {
+        'name': 'bool'
+      },
+      'required': false,
+      'description': 'Whether the cat is wide',
+      'defaultValue': {
+        'value': 'false',
+        'computed': false
+      }
+    },
+    'isLong': {
+      'type': {
+        'name': 'bool'
+      },
+      'required': false,
+      'description': 'Whether the cat is long',
+      'defaultValue': {
+        'value': 'false',
+        'computed': false
+      }
+    }
+  }
+};
+
+if (typeof STORYBOOK_REACT_CLASSES !== 'undefined') {
+  STORYBOOK_REACT_CLASSES['test/fixtures/reactCreateElement/actual.js'] = {
+    name: 'Kitten',
+    docgenInfo: Kitten.__docgenInfo,
+    path: 'test/fixtures/reactCreateElement/actual.js'
+  };
+}


### PR DESCRIPTION
React.createElement is currently not parsed. i.e. no __docgeninfo is generated.

These changes allow any exported component using React.createElement to be parsed.