### PR TITLE
Add support for higher order components with any arbitrary depth.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,7 +106,7 @@ function isExported(path, className, t){
       if (t.isCallExpression(decl)) {
         return className === findMostRightHandArgument(decl.arguments);
       } else {
-        return className === path.node.declaration.name;
+        return className === decl.name;
       }
     }
     return false;

--- a/src/index.js
+++ b/src/index.js
@@ -104,7 +104,7 @@ function isExported(path, className, t){
     } else if(path.node.type === 'ExportDefaultDeclaration') {
       const decl = path.node.declaration
       if (t.isCallExpression(decl)) {
-        return findMostRightHandArgument(decl.arguments);
+        return className === findMostRightHandArgument(decl.arguments);
       } else {
         return className === path.node.declaration.name;
       }

--- a/src/index.js
+++ b/src/index.js
@@ -81,6 +81,15 @@ function isExported(path, className, t){
     'ExportNamedDeclaration'
   ];
 
+  function findMostRightHandArgument(args = []) {
+    const arg = args[0]
+    if (t.isIdentifier(arg)) {
+      return arg.name
+    } else if(t.isCallExpression(arg)) {
+      return findMostRightHandArgument(arg.arguments)
+    }
+  }
+
   if(path.parentPath.node &&
      types.some(type => {return path.parentPath.node.type === type;})) {
     return true;
@@ -93,7 +102,12 @@ function isExported(path, className, t){
        path.node.specifiers.length) {
       return className === path.node.specifiers[0].exported.name;
     } else if(path.node.type === 'ExportDefaultDeclaration') {
-      return className === path.node.declaration.name;
+      const decl = path.node.declaration
+      if (t.isCallExpression(decl)) {
+        return findMostRightHandArgument(decl.arguments);
+      } else {
+        return className === path.node.declaration.name;
+      }
     }
     return false;
   });

--- a/test/fixtures/hoc-multiple/actual.js
+++ b/test/fixtures/hoc-multiple/actual.js
@@ -1,0 +1,19 @@
+/**
+ * Super tiny component
+ */
+class Component extends React.Component {
+  render() { return null }
+}
+
+Component.propTypes = {
+  /** Description for children */
+  children: React.PropTypes.string.isRequired,
+  /**
+   * What happens onClick stays onClick
+   */
+  onClick: React.PropTypes.func,
+  /** Fancy styles in here */
+  style: React.PropTypes.object,
+}
+
+export default withHoc()(deeperHoc(Component))

--- a/test/fixtures/hoc-multiple/expected.js
+++ b/test/fixtures/hoc-multiple/expected.js
@@ -1,0 +1,85 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+/**
+ * Super tiny component
+ */
+var Component = function (_React$Component) {
+  _inherits(Component, _React$Component);
+
+  function Component() {
+    _classCallCheck(this, Component);
+
+    return _possibleConstructorReturn(this, (Component.__proto__ || Object.getPrototypeOf(Component)).apply(this, arguments));
+  }
+
+  _createClass(Component, [{
+    key: "render",
+    value: function render() {
+      return null;
+    }
+  }]);
+
+  return Component;
+}(React.Component);
+
+Component.propTypes = {
+  /** Description for children */
+  children: React.PropTypes.string.isRequired,
+  /**
+   * What happens onClick stays onClick
+   */
+  onClick: React.PropTypes.func,
+  /** Fancy styles in here */
+  style: React.PropTypes.object
+};
+
+exports.default = withHoc()(deeperHoc(Component));
+Component.__docgenInfo = {
+  "description": "Super tiny component",
+  "props": {
+    "children": {
+      "type": {
+        "name": "custom",
+        "raw": "React.PropTypes.string.isRequired"
+      },
+      "required": false,
+      "description": "Description for children"
+    },
+    "onClick": {
+      "type": {
+        "name": "custom",
+        "raw": "React.PropTypes.func"
+      },
+      "required": false,
+      "description": "What happens onClick stays onClick"
+    },
+    "style": {
+      "type": {
+        "name": "custom",
+        "raw": "React.PropTypes.object"
+      },
+      "required": false,
+      "description": "Fancy styles in here"
+    }
+  }
+};
+
+if (typeof STORYBOOK_REACT_CLASSES !== "undefined") {
+  STORYBOOK_REACT_CLASSES["test/fixtures/hoc-multiple/actual.js"] = {
+    name: "Component",
+    docgenInfo: Component.__docgenInfo,
+    path: "test/fixtures/hoc-multiple/actual.js"
+  };
+}

--- a/test/fixtures/hoc/actual.js
+++ b/test/fixtures/hoc/actual.js
@@ -1,0 +1,11 @@
+class Component extends React.Component {
+  render() { return null }
+}
+
+Component.propTypes = {
+  children: React.PropTypes.string.isRequired,
+  onClick: React.PropTypes.func,
+  style: React.PropTypes.object,
+}
+
+export default withHoc()(deeperHoc(Component))

--- a/test/fixtures/hoc/actual.js
+++ b/test/fixtures/hoc/actual.js
@@ -1,11 +1,19 @@
+/**
+ * Super tiny component
+ */
 class Component extends React.Component {
   render() { return null }
 }
 
 Component.propTypes = {
+  /** Description for children */
   children: React.PropTypes.string.isRequired,
+  /**
+   * What happens onClick stays onClick
+   */
   onClick: React.PropTypes.func,
+  /** Fancy styles in here */
   style: React.PropTypes.object,
 }
 
-export default withHoc()(deeperHoc(Component))
+export default withHoc(Component)

--- a/test/fixtures/hoc/expected.js
+++ b/test/fixtures/hoc/expected.js
@@ -12,6 +12,9 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
+/**
+ * Super tiny component
+ */
 var Component = function (_React$Component) {
   _inherits(Component, _React$Component);
 
@@ -32,14 +35,19 @@ var Component = function (_React$Component) {
 }(React.Component);
 
 Component.propTypes = {
+  /** Description for children */
   children: React.PropTypes.string.isRequired,
+  /**
+   * What happens onClick stays onClick
+   */
   onClick: React.PropTypes.func,
+  /** Fancy styles in here */
   style: React.PropTypes.object
 };
 
-exports.default = withHoc()(deeperHoc(Component));
+exports.default = withHoc(Component);
 Component.__docgenInfo = {
-  "description": "",
+  "description": "Super tiny component",
   "props": {
     "children": {
       "type": {
@@ -47,7 +55,7 @@ Component.__docgenInfo = {
         "raw": "React.PropTypes.string.isRequired"
       },
       "required": false,
-      "description": ""
+      "description": "Description for children"
     },
     "onClick": {
       "type": {
@@ -55,7 +63,7 @@ Component.__docgenInfo = {
         "raw": "React.PropTypes.func"
       },
       "required": false,
-      "description": ""
+      "description": "What happens onClick stays onClick"
     },
     "style": {
       "type": {
@@ -63,7 +71,7 @@ Component.__docgenInfo = {
         "raw": "React.PropTypes.object"
       },
       "required": false,
-      "description": ""
+      "description": "Fancy styles in here"
     }
   }
 };

--- a/test/fixtures/hoc/expected.js
+++ b/test/fixtures/hoc/expected.js
@@ -1,0 +1,77 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var Component = function (_React$Component) {
+  _inherits(Component, _React$Component);
+
+  function Component() {
+    _classCallCheck(this, Component);
+
+    return _possibleConstructorReturn(this, (Component.__proto__ || Object.getPrototypeOf(Component)).apply(this, arguments));
+  }
+
+  _createClass(Component, [{
+    key: "render",
+    value: function render() {
+      return null;
+    }
+  }]);
+
+  return Component;
+}(React.Component);
+
+Component.propTypes = {
+  children: React.PropTypes.string.isRequired,
+  onClick: React.PropTypes.func,
+  style: React.PropTypes.object
+};
+
+exports.default = withHoc()(deeperHoc(Component));
+Component.__docgenInfo = {
+  "description": "",
+  "props": {
+    "children": {
+      "type": {
+        "name": "custom",
+        "raw": "React.PropTypes.string.isRequired"
+      },
+      "required": false,
+      "description": ""
+    },
+    "onClick": {
+      "type": {
+        "name": "custom",
+        "raw": "React.PropTypes.func"
+      },
+      "required": false,
+      "description": ""
+    },
+    "style": {
+      "type": {
+        "name": "custom",
+        "raw": "React.PropTypes.object"
+      },
+      "required": false,
+      "description": ""
+    }
+  }
+};
+
+if (typeof STORYBOOK_REACT_CLASSES !== "undefined") {
+  STORYBOOK_REACT_CLASSES["test/fixtures/hoc/actual.js"] = {
+    name: "Component",
+    docgenInfo: Component.__docgenInfo,
+    path: "test/fixtures/hoc/actual.js"
+  };
+}


### PR DESCRIPTION
We have the need to support higher-order-components in our docs.
So I added the possibility for the plugin to also provide information about these.

For example this needs to be supported:
`export default connect()(withRouter(MyComponent))`

It's supported by `react-docgen` but not by this plugin. With this PR it should also work here :)