### PR TITLE
adds support for resolver and includeMethods option in .babelrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,14 @@ So, we allow you to collect all the docgen info into a global collection. To do 
 ```json
 {
   "plugins":[
-    ["babel-plugin-react-docgen", { "DOC_GEN_COLLECTION_NAME": "MY_REACT_DOCS"}]
+    [
+      "babel-plugin-react-docgen", 
+      { 
+        "DOC_GEN_COLLECTION_NAME": "MY_REACT_DOCS",
+        "resolver": "findAllExportedComponentDefinitions", // optional (default: undefined)
+        "keepMethods": true // optional (default: false)
+      }
+    ]
   ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ Use it inside your `.babelrc`
 }
 ```
 
+## .babelrc Options
+
+|  option  |  description   |  default   |
+| --- | --- | --- |
+|   resolver  |   [react-docgen](https://github.com/reactjs/react-docgen) has 3 built in resolvers which may be used. Resolvers define how/what the doc generator will inspect. You may inspect the existing resolvers in [https://github.com/reactjs/react-docgen/tree/master/src/resolver](react-docgen/src/resolver).  | ```"findExportedComponentDefinition"``` |
+|   includeMethods  | by default this plugin will remove method information about react components since it should not be needed in most cases |   ```false```  |
+
 ## Collect All Docgen Info
 
 Sometimes, it's a pretty good idea to collect all of the docgen info into a collection. Then you could use that to render style guide or similar.
@@ -97,7 +104,7 @@ So, we allow you to collect all the docgen info into a global collection. To do 
       { 
         "DOC_GEN_COLLECTION_NAME": "MY_REACT_DOCS",
         "resolver": "findAllExportedComponentDefinitions", // optional (default: undefined)
-        "keepMethods": true // optional (default: false)
+        "includeMethods": true // optional (default: false)
       }
     ]
   ]

--- a/src/index.js
+++ b/src/index.js
@@ -143,7 +143,7 @@ function injectReactDocgenInfo(className, path, state, code, t) {
 
     docObj = reactDocs.parse(code, resolver);
     
-    if (!state.opts.keepMethods) {
+    if (!state.opts.includeMethods) {
       delete docObj.methods;
     }
   } catch(e) {

--- a/src/index.js
+++ b/src/index.js
@@ -135,15 +135,19 @@ function injectReactDocgenInfo(className, path, state, code, t) {
 
   let docObj = {};
   try {
-    docObj = reactDocs.parse(code);
-    // We don't need anything about methods.
-    // Usually we don't use methods in react classes as a public API.
-    // Even if we do so, that's an anti-pattern.
-    // TODO:
-    //  Anyway, some may need this,
-    //  so we should provide an option to stop deleting methods.
-    delete docObj.methods;
+    let resolver;
+
+    if (state.opts.resolver) {
+      resolver = require('react-docgen').resolver[state.opts.resolver];
+    }
+
+    docObj = reactDocs.parse(code, resolver);
+    
+    if (!state.opts.keepMethods) {
+      delete docObj.methods;
+    }
   } catch(e) {
+    console.error(e);
     return;
   }
 


### PR DESCRIPTION
This PR adds support for configuring/passing down a resolver option to react-docgen via the plugin options.

It makes the example mentioned by @konsumer in #33 work.

It also allows to pass a boolean option "includeMethods" in order to make the loader ... keep the methods of the components doc info. (default is false)

I'm afraid I'm not sure how to create a new test for this addition though - so any help would be appreciated!

To use the options you can specify the plugin like this:

in **.babelrc**
```json
{
  "plugins": [
    [ 
      "react-docgen", 
      { 
        "includeMethods": true, 
        "resolver": "findAllComponentDefinitions"
       }
    ]
  ]
}

EDIT: renamed "keepMethods" to "includeMethods"