### PR TITLE
Add support for module exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -111,6 +111,24 @@ function isExported(path, className, t){
       } else {
         return className === decl.name;
       }
+    // Detect module.exports = className;
+    } else if(path.node.type === 'ExpressionStatement') {
+      const expr = path.node.expression
+
+      if (t.isAssignmentExpression(expr)) {
+        const left = expr.left;
+        const right = expr.right;
+
+        const leftIsModuleExports = t.isMemberExpression(left) &&
+            t.isIdentifier(left.object) &&
+            t.isIdentifier(left.property) &&
+            left.object.name === 'module' &&
+            left.property.name === 'exports';
+
+        const rightIsIdentifierClass = t.isIdentifier(right) && right.name === className;
+
+        return leftIsModuleExports && rightIsIdentifierClass;
+      }
     }
     return false;
   });

--- a/test/fixtures/example-module-exports/actual.js
+++ b/test/fixtures/example-module-exports/actual.js
@@ -1,0 +1,19 @@
+import React, { Component } from 'react';
+import logo from './logo.svg';
+import './App.css';
+
+function App() {
+    return (
+      <div className="App">
+        <div className="App-header">
+          <img src={logo} className="App-logo" alt="logo" />
+          <h2>Welcome to React</h2>
+        </div>
+        <p className="App-intro">
+          To get started, edit <code>src/App.js</code> and save to reload.
+        </p>
+      </div>
+    );
+}
+
+module.exports = App;

--- a/test/fixtures/example-module-exports/expected.js
+++ b/test/fixtures/example-module-exports/expected.js
@@ -1,0 +1,55 @@
+'use strict';
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _logo = require('./logo.svg');
+
+var _logo2 = _interopRequireDefault(_logo);
+
+require('./App.css');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function App() {
+  return _react2.default.createElement(
+    'div',
+    { className: 'App' },
+    _react2.default.createElement(
+      'div',
+      { className: 'App-header' },
+      _react2.default.createElement('img', { src: _logo2.default, className: 'App-logo', alt: 'logo' }),
+      _react2.default.createElement(
+        'h2',
+        null,
+        'Welcome to React'
+      )
+    ),
+    _react2.default.createElement(
+      'p',
+      { className: 'App-intro' },
+      'To get started, edit ',
+      _react2.default.createElement(
+        'code',
+        null,
+        'src/App.js'
+      ),
+      ' and save to reload.'
+    )
+  );
+}
+
+module.exports = App;
+App.__docgenInfo = {
+  'description': '',
+  'displayName': 'App'
+};
+
+if (typeof STORYBOOK_REACT_CLASSES !== 'undefined') {
+  STORYBOOK_REACT_CLASSES['test/fixtures/example-module-exports/actual.js'] = {
+    name: 'App',
+    docgenInfo: App.__docgenInfo,
+    path: 'test/fixtures/example-module-exports/actual.js'
+  };
+}


### PR DESCRIPTION
**This PR adds basic support for module.exports which will generate docgen info for CommonJS modules.**

At Badoo we are building our own design system UI, however we currently use CommonJS modules and it means that we can't use babel-plugin-react-docgen yet.

I have added some tests as well. Please note that with existing package.json some other unit tests are failing for me, I had to upgrade docgen to get them to pass however probably it's not the right place for this PR.