### PR TITLE
Flatten parsed docs if an array

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "micromatch": "2.3.11",
         "normalize-path": "2.1.1"
@@ -40,7 +41,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "array-unique": {
       "version": "0.2.1",
@@ -1039,7 +1041,8 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.9.0.tgz",
       "integrity": "sha1-ZlBsFs5vTWkopbPNajPKQelB43s=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "brace-expansion": {
       "version": "1.1.8",
@@ -1255,6 +1258,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
       "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "nan": "2.6.2",
         "node-pre-gyp": "0.6.36"
@@ -1263,12 +1267,14 @@
         "abbrev": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ajv": {
           "version": "4.11.8",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "co": "4.6.0",
             "json-stable-stringify": "1.0.1"
@@ -1282,12 +1288,14 @@
         "aproba": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "delegates": "1.0.0",
             "readable-stream": "2.2.9"
@@ -1296,27 +1304,32 @@
         "asn1": {
           "version": "0.2.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "assert-plus": {
           "version": "0.2.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "asynckit": {
           "version": "0.4.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aws-sign2": {
           "version": "0.6.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aws4": {
           "version": "1.6.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "balanced-match": {
           "version": "0.4.2",
@@ -1365,12 +1378,14 @@
         "caseless": {
           "version": "0.12.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "co": {
           "version": "4.6.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
@@ -1404,6 +1419,7 @@
           "version": "2.0.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "boom": "2.10.1"
           }
@@ -1412,6 +1428,7 @@
           "version": "1.14.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "assert-plus": "1.0.0"
           },
@@ -1419,7 +1436,8 @@
             "assert-plus": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -1427,6 +1445,7 @@
           "version": "2.6.8",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -1434,7 +1453,8 @@
         "deep-extend": {
           "version": "0.4.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "delayed-stream": {
           "version": "1.0.0",
@@ -1444,7 +1464,8 @@
         "delegates": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ecc-jsbn": {
           "version": "0.1.1",
@@ -1458,7 +1479,8 @@
         "extend": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "extsprintf": {
           "version": "1.0.2",
@@ -1468,12 +1490,14 @@
         "forever-agent": {
           "version": "0.6.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "form-data": {
           "version": "2.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "asynckit": "0.4.0",
             "combined-stream": "1.0.5",
@@ -1500,6 +1524,7 @@
           "version": "1.0.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "fstream": "1.0.11",
             "inherits": "2.0.3",
@@ -1510,6 +1535,7 @@
           "version": "2.7.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "aproba": "1.1.1",
             "console-control-strings": "1.1.0",
@@ -1525,6 +1551,7 @@
           "version": "0.1.7",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "assert-plus": "1.0.0"
           },
@@ -1532,7 +1559,8 @@
             "assert-plus": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -1557,12 +1585,14 @@
         "har-schema": {
           "version": "1.0.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "har-validator": {
           "version": "4.2.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ajv": "4.11.8",
             "har-schema": "1.0.5"
@@ -1571,12 +1601,14 @@
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "hawk": {
           "version": "3.1.3",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "boom": "2.10.1",
             "cryptiles": "2.0.5",
@@ -1593,6 +1625,7 @@
           "version": "1.1.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "assert-plus": "0.2.0",
             "jsprim": "1.4.0",
@@ -1616,7 +1649,8 @@
         "ini": {
           "version": "1.3.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
@@ -1629,7 +1663,8 @@
         "is-typedarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "isarray": {
           "version": "1.0.0",
@@ -1639,7 +1674,8 @@
         "isstream": {
           "version": "0.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "jodid25519": {
           "version": "1.0.2",
@@ -1659,12 +1695,14 @@
         "json-schema": {
           "version": "0.2.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "json-stable-stringify": {
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "jsonify": "0.0.0"
           }
@@ -1672,17 +1710,20 @@
         "json-stringify-safe": {
           "version": "5.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "jsonify": {
           "version": "0.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "jsprim": {
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "assert-plus": "1.0.0",
             "extsprintf": "1.0.2",
@@ -1693,7 +1734,8 @@
             "assert-plus": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -1734,12 +1776,14 @@
         "ms": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "node-pre-gyp": {
           "version": "0.6.36",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "mkdirp": "0.5.1",
             "nopt": "4.0.1",
@@ -1756,6 +1800,7 @@
           "version": "4.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "abbrev": "1.1.0",
             "osenv": "0.1.4"
@@ -1765,6 +1810,7 @@
           "version": "4.1.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "are-we-there-yet": "1.1.4",
             "console-control-strings": "1.1.0",
@@ -1780,12 +1826,14 @@
         "oauth-sign": {
           "version": "0.8.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "once": {
           "version": "1.4.0",
@@ -1798,17 +1846,20 @@
         "os-homedir": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "osenv": {
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "os-homedir": "1.0.2",
             "os-tmpdir": "1.0.2"
@@ -1822,7 +1873,8 @@
         "performance-now": {
           "version": "0.2.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "process-nextick-args": {
           "version": "1.0.7",
@@ -1832,17 +1884,20 @@
         "punycode": {
           "version": "1.4.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "qs": {
           "version": "6.4.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "rc": {
           "version": "1.2.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "deep-extend": "0.4.2",
             "ini": "1.3.4",
@@ -1853,7 +1908,8 @@
             "minimist": {
               "version": "1.2.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -1875,6 +1931,7 @@
           "version": "2.81.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "aws-sign2": "0.6.0",
             "aws4": "1.6.0",
@@ -1916,22 +1973,26 @@
         "semver": {
           "version": "5.3.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "sntp": {
           "version": "1.0.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "hoek": "2.16.3"
           }
@@ -1940,6 +2001,7 @@
           "version": "1.13.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "asn1": "0.2.3",
             "assert-plus": "1.0.0",
@@ -1955,7 +2017,8 @@
             "assert-plus": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -1980,7 +2043,8 @@
         "stringstream": {
           "version": "0.0.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "strip-ansi": {
           "version": "3.0.1",
@@ -1993,7 +2057,8 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "tar": {
           "version": "2.2.1",
@@ -2009,6 +2074,7 @@
           "version": "3.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "debug": "2.6.8",
             "fstream": "1.0.11",
@@ -2024,6 +2090,7 @@
           "version": "2.3.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "punycode": "1.4.1"
           }
@@ -2032,6 +2099,7 @@
           "version": "0.6.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "5.0.1"
           }
@@ -2045,7 +2113,8 @@
         "uid-number": {
           "version": "0.0.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "util-deprecate": {
           "version": "1.0.2",
@@ -2055,12 +2124,14 @@
         "uuid": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "verror": {
           "version": "1.3.6",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "extsprintf": "1.0.2"
           }
@@ -2069,6 +2140,7 @@
           "version": "1.1.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "string-width": "1.0.2"
           }
@@ -2196,7 +2268,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
       "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-equal-shallow": {
       "version": "0.1.3",
@@ -2594,6 +2667,7 @@
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-number": "3.0.0",
         "kind-of": "4.0.0"
@@ -2604,6 +2678,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "3.2.2"
           },
@@ -2613,6 +2688,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "is-buffer": "1.1.5"
               }
@@ -2624,6 +2700,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "1.1.5"
           }
@@ -2649,6 +2726,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
@@ -2823,6 +2901,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "safe-buffer": "5.1.1"
       }

--- a/src/index.js
+++ b/src/index.js
@@ -162,7 +162,8 @@ function injectReactDocgenInfo(className, path, state, code, t) {
       resolver = require('react-docgen').resolver[state.opts.resolver];
     }
 
-    docObj = reactDocs.parse(code, resolver);
+    const parsedDocs = reactDocs.parse(code, resolver);
+    docObj = Object.prototype.toString.call(parsedDocs) == '[object Array]' ? parsedDocs[0] : parsedDocs;
 
     if (!state.opts.includeMethods) {
       delete docObj.methods;


### PR DESCRIPTION
When using `findAllExportedComponentDefinitions` resolver, the parsed react docs are an array holding the nested `__docgenInfo` object . `@storybook/addon-info` cannot read the `__docgenInfo` because it expects an object. This PR flattens the array into a format that is consistent with the default resolver and can be read by `addon-info`.