### PR TITLE
[Suggestion] Allow supporting of required prop in enums and shapes

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "babel-types": "^6.24.1",
     "lodash": "^4.17.0",
-    "react-docgen": "^2.20.0"
+    "react-docgen": "https://github.com/NikhilVerma/react-docgen/archive/v3.0.0-beta12.tar.gz"
   },
   "license": "MIT"
 }

--- a/test/fixtures/case1/expected.js
+++ b/test/fixtures/case1/expected.js
@@ -205,7 +205,8 @@ CalendarDay.__docgenInfo = {
         'name': 'arrayOf',
         'value': {
           'name': 'string'
-        }
+        },
+        'required': false
       },
       'required': false,
       'description': '',

--- a/test/fixtures/case3/expected.js
+++ b/test/fixtures/case3/expected.js
@@ -44,6 +44,7 @@ function abc() {
 }
 Button.__docgenInfo = {
   'description': '',
+  'displayName': 'Button',
   'props': {
     'children': {
       'type': {

--- a/test/fixtures/case5/expected.js
+++ b/test/fixtures/case5/expected.js
@@ -35,6 +35,7 @@ First.propTypes = {
 exports.default = First;
 First.__docgenInfo = {
   'description': '',
+  'displayName': 'First',
   'props': {
     'children': {
       'type': {

--- a/test/fixtures/case7/expected.js
+++ b/test/fixtures/case7/expected.js
@@ -36,6 +36,7 @@ First.propTypes = {
 exports.First = First;
 First.__docgenInfo = {
   'description': '',
+  'displayName': 'First',
   'props': {
     'children': {
       'type': {

--- a/test/fixtures/reactCreateElement/expected.js
+++ b/test/fixtures/reactCreateElement/expected.js
@@ -35,6 +35,7 @@ Kitten.defaultProps = {
 exports.default = Kitten;
 Kitten.__docgenInfo = {
   'description': '',
+  'displayName': 'Kitten',
   'props': {
     'isWide': {
       'type': {

--- a/test/fixtures/shape/actual.js
+++ b/test/fixtures/shape/actual.js
@@ -1,0 +1,33 @@
+import React from 'react';
+
+const Button = ({ children, onClick, style = {} }) => (
+  <button
+    style={{ }}
+    onClick={onClick}
+  >
+    {children}
+  </button>
+);
+
+Button.propTypes = {
+  children: React.PropTypes.string.isRequired,
+  onClick: React.PropTypes.func,
+  style: React.PropTypes.object,
+  icon: React.PropTypes.shape({
+    /**
+     * The name of the icon to show in the brick
+     */
+    name: React.PropTypes.string
+  }).isRequired
+};
+
+export default Button;
+
+let A;
+A = [1,2,2,2];
+
+function abc() {
+  let c = function cef() {
+    A = 'str';
+  };
+}

--- a/test/fixtures/shape/expected.js
+++ b/test/fixtures/shape/expected.js
@@ -15,7 +15,6 @@ var Button = function Button(_ref) {
       onClick = _ref.onClick,
       _ref$style = _ref.style,
       style = _ref$style === undefined ? {} : _ref$style;
-
   return _react2.default.createElement(
     'button',
     {
@@ -29,7 +28,13 @@ var Button = function Button(_ref) {
 Button.propTypes = {
   children: _react2.default.PropTypes.string.isRequired,
   onClick: _react2.default.PropTypes.func,
-  style: _react2.default.PropTypes.object
+  style: _react2.default.PropTypes.object,
+  icon: _react2.default.PropTypes.shape({
+    /**
+     * The name of the icon to show in the brick
+     */
+    name: _react2.default.PropTypes.string
+  }).isRequired
 };
 
 exports.default = Button;
@@ -71,14 +76,29 @@ Button.__docgenInfo = {
         'value': '{}',
         'computed': false
       }
+    },
+    'icon': {
+      'type': {
+        'name': 'shape',
+        'value': {
+          'name': {
+            'name': 'string',
+            'description': 'The name of the icon to show in the brick',
+            'required': false
+          }
+        },
+        'required': true
+      },
+      'required': true,
+      'description': ''
     }
   }
 };
 
 if (typeof STORYBOOK_REACT_CLASSES !== 'undefined') {
-  STORYBOOK_REACT_CLASSES['test/fixtures/case4/actual.js'] = {
+  STORYBOOK_REACT_CLASSES['test/fixtures/shape/actual.js'] = {
     name: 'Button',
     docgenInfo: Button.__docgenInfo,
-    path: 'test/fixtures/case4/actual.js'
+    path: 'test/fixtures/shape/actual.js'
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1681,9 +1681,9 @@ rc@~1.1.0:
     minimist "^1.2.0"
     strip-json-comments "~1.0.4"
 
-react-docgen@^2.20.0:
-  version "2.20.0"
-  resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-2.20.0.tgz#41a6da483a34a4aaed041a9909f5e61864d681cb"
+"react-docgen@https://github.com/NikhilVerma/react-docgen/archive/v3.0.0-beta12.tar.gz":
+  version "2.20.1"
+  resolved "https://github.com/NikhilVerma/react-docgen/archive/v3.0.0-beta12.tar.gz#154da4269e038fc304fa41fae8bbcf04da9fda0a"
   dependencies:
     async "^2.1.4"
     babel-runtime "^6.9.2"


### PR DESCRIPTION
This is a suggestion based on top of https://github.com/reactjs/react-docgen/pull/261

This upgrades docgen to latest version + my fix to detect required on shapes and enums. We probably shouldn't merge it until it's merged in the first PR.

But I wanted to share this anyway because it can potentially solve the problems we were having for others.