### PR TITLE
Use react-docgen for all exported components, don't remove method info by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # ChangeLog
 
+### v2.0.0
+
+Breaking changes:
+* Use `findAllExportedComponentDefinitions` by default to generate info for named exports
+* Default to not remove method info and changed `.babelrc` key to `removeMethods`
+
+Bug fixes:
+* Fix for named export using incorrect local name in `export default ComponentName`
+[PR38](https://github.com/storybooks/babel-plugin-react-docgen/pull/38)
+
 ### v1.9.0
 04-April-2018
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Use it inside your `.babelrc`
 
 |  option  |  description   |  default   |
 | --- | --- | --- |
-|   resolver  |   [react-docgen](https://github.com/reactjs/react-docgen) has 3 built in resolvers which may be used. Resolvers define how/what the doc generator will inspect. You may inspect the existing resolvers in [react-docgen/tree/master/src/resolver](https://github.com/reactjs/react-docgen/tree/master/src/resolver).  | ```"findExportedComponentDefinition"``` |
+|   resolver  |   [react-docgen](https://github.com/reactjs/react-docgen) has 3 built in resolvers which may be used. Resolvers define how/what the doc generator will inspect. You may inspect the existing resolvers in [react-docgen/tree/master/src/resolver](https://github.com/reactjs/react-docgen/tree/master/src/resolver).  | ```"findAllExportedComponentDefinition"``` |
 |   includeMethods  | by default this plugin will remove method information about react components since it should not be needed in most cases |   ```false```  |
 
 ## Collect All Docgen Info
@@ -96,14 +96,14 @@ Sometimes, it's a pretty good idea to collect all of the docgen info into a coll
 
 So, we allow you to collect all the docgen info into a global collection. To do that, add following config to when loading this babel plugin:
 
-```json
+```js
 {
   "plugins":[
     [
-      "babel-plugin-react-docgen", 
-      { 
+      "babel-plugin-react-docgen",
+      {
         "DOC_GEN_COLLECTION_NAME": "MY_REACT_DOCS",
-        "resolver": "findAllExportedComponentDefinitions", // optional (default: undefined)
+        "resolver": "findAllComponentDefinitions", // optional (default: findAllComponentDefinitions)
         "includeMethods": true // optional (default: false)
       }
     ]

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Use it inside your `.babelrc`
 |  option  |  description   |  default   |
 | --- | --- | --- |
 |   resolver  |   [react-docgen](https://github.com/reactjs/react-docgen) has 3 built in resolvers which may be used. Resolvers define how/what the doc generator will inspect. You may inspect the existing resolvers in [react-docgen/tree/master/src/resolver](https://github.com/reactjs/react-docgen/tree/master/src/resolver).  | ```"findAllExportedComponentDefinition"``` |
-|   includeMethods  | by default this plugin will remove method information about react components since it should not be needed in most cases |   ```false```  |
+|   removeMethods  | optionally remove docgen information about methods |   ```false```  |
 
 ## Collect All Docgen Info
 
@@ -104,7 +104,7 @@ So, we allow you to collect all the docgen info into a global collection. To do 
       {
         "DOC_GEN_COLLECTION_NAME": "MY_REACT_DOCS",
         "resolver": "findAllComponentDefinitions", // optional (default: findAllComponentDefinitions)
-        "includeMethods": true // optional (default: false)
+        "removeMethods": true // optional (default: false)
       }
     ]
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-react-docgen",
-  "version": "1.9.0",
+  "version": "2.0.0-rc.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.9.0",
+  "version": "2.0.0-rc.0",
   "name": "babel-plugin-react-docgen",
   "description": "Babel plugin to add react-docgen info into your code",
   "repository": "https://github.com/storybooks/babel-plugin-react-docgen",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import * as reactDocs from 'react-docgen';
+import { parse as ReactDocgenParse, resolver as ReactDocgenResolver } from 'react-docgen';
 import isReactComponentClass from './isReactComponentClass';
 import isStatelessComponent from './isStatelessComponent';
 import * as p from 'path';
@@ -156,32 +156,53 @@ function injectReactDocgenInfo(className, path, state, code, t) {
     return;
   }
 
-  let docObj = {};
-  try {
-    let resolver;
+  let docgenResults = [];
+  try { // all exported component definitions includes named exports
+    let resolver = ReactDocgenResolver.findAllExportedComponentDefinitions;
 
     if (state.opts.resolver) {
-      resolver = require('react-docgen').resolver[state.opts.resolver];
+      resolver = ReactDocgenResolver[state.opts.resolver];
     }
 
-    docObj = reactDocs.parse(code, resolver);
+    docgenResults = ReactDocgenParse(code, resolver);
 
     if (!state.opts.includeMethods) {
-      delete docObj.methods;
+      docgenResults.forEach(function(docgenResult) {
+        delete docgenResult.methods;
+      })
     }
   } catch(e) {
+    // this is for debugging the error only, do not ship this console log or else it pollutes the webpack output
+    // console.log(e);
     return;
   }
 
-  const docNode = buildObjectExpression(docObj, t);
-  const docgenInfo = t.expressionStatement(
-    t.assignmentExpression(
-      "=",
-      t.memberExpression(t.identifier(className), t.identifier('__docgenInfo')),
-      docNode
-    ));
-  program.pushContainer('body', docgenInfo);
-  injectDocgenGlobal(className, path, state, t);
+  // docgen sometimes doesn't include 'displayName' which is the react function/class name
+  // the first time it's not available, we try to match it to the export name
+  let isDefaultClassNameUsed = false;
+
+  docgenResults.forEach(function(docgenResult, index) {
+    if (isDefaultClassNameUsed && !docgenResult.displayName) {
+      return;
+    }
+
+    let exportName = docgenResult.displayName;
+    if (!exportName) {
+      exportName = className;
+      isDefaultClassNameUsed = true;
+    }
+
+    const docNode = buildObjectExpression(docgenResult, t);
+    const docgenInfo = t.expressionStatement(
+      t.assignmentExpression(
+        "=",
+        t.memberExpression(t.identifier(exportName), t.identifier('__docgenInfo')),
+        docNode
+      ));
+    program.pushContainer('body', docgenInfo);
+
+    injectDocgenGlobal(exportName, path, state, t);
+  });
 }
 
 function injectDocgenGlobal(className, path, state, t) {

--- a/src/index.js
+++ b/src/index.js
@@ -166,7 +166,7 @@ function injectReactDocgenInfo(className, path, state, code, t) {
 
     docgenResults = ReactDocgenParse(code, resolver);
 
-    if (!state.opts.includeMethods) {
+    if (state.opts.removeMethods) {
       docgenResults.forEach(function(docgenResult) {
         delete docgenResult.methods;
       })

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 import * as _ from 'lodash';
-import { parse as ReactDocgenParse, resolver as ReactDocgenResolver } from 'react-docgen';
+import * as ReactDocgen from 'react-docgen';
 import isReactComponentClass from './isReactComponentClass';
 import isStatelessComponent from './isStatelessComponent';
-import * as p from 'path';
+import * as Path from 'path';
 
 export default function ({types: t}) {
   return {
@@ -158,13 +158,13 @@ function injectReactDocgenInfo(className, path, state, code, t) {
 
   let docgenResults = [];
   try { // all exported component definitions includes named exports
-    let resolver = ReactDocgenResolver.findAllExportedComponentDefinitions;
+    let resolver = ReactDocgen.resolver.findAllExportedComponentDefinitions;
 
     if (state.opts.resolver) {
-      resolver = ReactDocgenResolver[state.opts.resolver];
+      resolver = ReactDocgen.resolver[state.opts.resolver];
     }
 
-    docgenResults = ReactDocgenParse(code, resolver);
+    docgenResults = ReactDocgen.parse(code, resolver);
 
     if (state.opts.removeMethods) {
       docgenResults.forEach(function(docgenResult) {
@@ -213,7 +213,7 @@ function injectDocgenGlobal(className, path, state, t) {
   }
 
   const globalName = state.opts.DOC_GEN_COLLECTION_NAME;
-  const filePath = p.relative('./', p.resolve('./', path.hub.file.opts.filename));
+  const filePath = Path.relative('./', Path.resolve('./', path.hub.file.opts.filename));
   const globalNode = t.ifStatement(
     t.binaryExpression(
       '!==',

--- a/src/isReactComponentClass.js
+++ b/src/isReactComponentClass.js
@@ -1,7 +1,7 @@
-import * as types from 'babel-types';
+import * as BabelTypes from 'babel-types';
 
 function isRenderMethod(node) {
-  return types.isClassMethod(node) &&
+  return BabelTypes.isClassMethod(node) &&
     !node.computed &&
     !node.static &&
     (node.kind === '' || node.kind === 'method') &&
@@ -10,8 +10,8 @@ function isRenderMethod(node) {
 
 export default function isReactComponentClass(path) {
   var node = path.node;
-  if (!types.isClassDeclaration(node) &&
-    !types.isClassExpression(node)) {
+  if (!BabelTypes.isClassDeclaration(node) &&
+    !BabelTypes.isClassExpression(node)) {
     return false;
   }
 
@@ -26,7 +26,7 @@ export default function isReactComponentClass(path) {
   }
   var superClass = path.get('superClass');
   if (
-    (types.isMemberExpression(superClass.node) && superClass.get('property').node.name != 'Component')
+    (BabelTypes.isMemberExpression(superClass.node) && superClass.get('property').node.name != 'Component')
       || superClass.node.name != 'Component'
   ) {
     return false;

--- a/test/fixtures/case1/actual.js
+++ b/test/fixtures/case1/actual.js
@@ -42,7 +42,13 @@ export default class CalendarDay extends React.Component {
   shouldComponentUpdate(nextProps, nextState) {
     return shallowCompare(this, nextProps, nextState);
   }
-
+  /**
+   * Some description about how handleDayClick works
+   * @param  {Object} day this is a moment js object
+   * @param  {number|string} modifiers hello world
+   * @param  {number=} e events yo
+   * @return {*} wut return
+   */
   handleDayClick(day, modifiers, e) {
     this.props.onDayClick(day, modifiers, e);
   }

--- a/test/fixtures/case1/expected.js
+++ b/test/fixtures/case1/expected.js
@@ -187,6 +187,127 @@ CalendarDay.defaultProps = defaultProps;
 CalendarDay.__docgenInfo = {
   'description': '',
   'displayName': 'CalendarDay',
+  'methods': [{
+    'name': 'handleDayClick',
+    'docblock': null,
+    'modifiers': [],
+    'params': [{
+      'name': 'day',
+      'type': null
+    }, {
+      'name': 'modifiers',
+      'type': null
+    }, {
+      'name': 'e',
+      'type': null
+    }],
+    'returns': null
+  }, {
+    'name': 'handleDayMouseDown',
+    'docblock': null,
+    'modifiers': [],
+    'params': [{
+      'name': 'day',
+      'type': null
+    }, {
+      'name': 'modifiers',
+      'type': null
+    }, {
+      'name': 'e',
+      'type': null
+    }],
+    'returns': null
+  }, {
+    'name': 'handleDayMouseUp',
+    'docblock': null,
+    'modifiers': [],
+    'params': [{
+      'name': 'day',
+      'type': null
+    }, {
+      'name': 'modifiers',
+      'type': null
+    }, {
+      'name': 'e',
+      'type': null
+    }],
+    'returns': null
+  }, {
+    'name': 'handleDayMouseEnter',
+    'docblock': null,
+    'modifiers': [],
+    'params': [{
+      'name': 'day',
+      'type': null
+    }, {
+      'name': 'modifiers',
+      'type': null
+    }, {
+      'name': 'e',
+      'type': null
+    }],
+    'returns': null
+  }, {
+    'name': 'handleDayMouseLeave',
+    'docblock': null,
+    'modifiers': [],
+    'params': [{
+      'name': 'day',
+      'type': null
+    }, {
+      'name': 'modifiers',
+      'type': null
+    }, {
+      'name': 'e',
+      'type': null
+    }],
+    'returns': null
+  }, {
+    'name': 'handleDayTouchStart',
+    'docblock': null,
+    'modifiers': [],
+    'params': [{
+      'name': 'day',
+      'type': null
+    }, {
+      'name': 'modifiers',
+      'type': null
+    }, {
+      'name': 'e',
+      'type': null
+    }],
+    'returns': null
+  }, {
+    'name': 'handleDayTouchEnd',
+    'docblock': null,
+    'modifiers': [],
+    'params': [{
+      'name': 'day',
+      'type': null
+    }, {
+      'name': 'modifiers',
+      'type': null
+    }, {
+      'name': 'e',
+      'type': null
+    }],
+    'returns': null
+  }, {
+    'name': 'handleDayTouchTap',
+    'docblock': null,
+    'modifiers': [],
+    'params': [{
+      'name': 'day',
+      'type': null
+    }, {
+      'name': 'modifiers',
+      'type': null
+    }, {
+      'name': 'e',
+      'type': null
+    }],
+    'returns': null
+  }],
   'props': {
     'day': {
       'type': {

--- a/test/fixtures/case1/expected.js
+++ b/test/fixtures/case1/expected.js
@@ -79,6 +79,14 @@ var CalendarDay = function (_React$Component) {
     value: function shouldComponentUpdate(nextProps, nextState) {
       return (0, _reactAddonsShallowCompare2.default)(this, nextProps, nextState);
     }
+    /**
+     * Some description about how handleDayClick works
+     * @param  {Object} day this is a moment js object
+     * @param  {number|string} modifiers hello world
+     * @param  {number=} e events yo
+     * @return {*} wut return
+     */
+
   }, {
     key: 'handleDayClick',
     value: function handleDayClick(day, modifiers, e) {
@@ -189,19 +197,36 @@ CalendarDay.__docgenInfo = {
   'displayName': 'CalendarDay',
   'methods': [{
     'name': 'handleDayClick',
-    'docblock': null,
+    'docblock': 'Some description about how handleDayClick works\n@param  {Object} day this is a moment js object\n@param  {number|string} modifiers hello world\n@param  {number=} e events yo\n@return {*} wut return',
     'modifiers': [],
     'params': [{
       'name': 'day',
-      'type': null
+      'description': 'this is a moment js object',
+      'type': {
+        'name': 'Object'
+      }
     }, {
       'name': 'modifiers',
-      'type': null
+      'description': 'hello world',
+      'type': {
+        'name': 'union',
+        'value': ['number', 'string']
+      }
     }, {
       'name': 'e',
-      'type': null
+      'description': 'events yo',
+      'type': {
+        'name': 'number'
+      },
+      'optional': true
     }],
-    'returns': null
+    'returns': {
+      'description': 'wut return',
+      'type': {
+        'name': 'mixed'
+      }
+    },
+    'description': 'Some description about how handleDayClick works'
   }, {
     'name': 'handleDayMouseDown',
     'docblock': null,

--- a/test/fixtures/case2/expected.js
+++ b/test/fixtures/case2/expected.js
@@ -54,6 +54,7 @@ exports.default = ErrorBox;
 ErrorBox.__docgenInfo = {
   'description': '',
   'displayName': 'ErrorBox',
+  'methods': [],
   'props': {
     'children': {
       'type': {

--- a/test/fixtures/case3/expected.js
+++ b/test/fixtures/case3/expected.js
@@ -44,6 +44,7 @@ function abc() {
 }
 Button.__docgenInfo = {
   'description': '',
+  'methods': [],
   'props': {
     'children': {
       'type': {

--- a/test/fixtures/case4/expected.js
+++ b/test/fixtures/case4/expected.js
@@ -45,6 +45,7 @@ function abc() {
 }
 Button.__docgenInfo = {
   'description': '',
+  'methods': [],
   'props': {
     'children': {
       'type': {

--- a/test/fixtures/case5/expected.js
+++ b/test/fixtures/case5/expected.js
@@ -35,6 +35,7 @@ First.propTypes = {
 exports.default = First;
 First.__docgenInfo = {
   'description': '',
+  'methods': [],
   'props': {
     'children': {
       'type': {

--- a/test/fixtures/case7/expected.js
+++ b/test/fixtures/case7/expected.js
@@ -36,6 +36,7 @@ First.propTypes = {
 exports.First = First;
 First.__docgenInfo = {
   'description': '',
+  'methods': [],
   'props': {
     'children': {
       'type': {

--- a/test/fixtures/case8/expected.js
+++ b/test/fixtures/case8/expected.js
@@ -62,6 +62,7 @@ Wrapper.propTypes = {
 Wrapper.__docgenInfo = {
   "description": "",
   "displayName": "Wrapper",
+  "methods": [],
   "props": {
     "children": {
       "type": {

--- a/test/fixtures/createReactClass/expected.js
+++ b/test/fixtures/createReactClass/expected.js
@@ -43,6 +43,7 @@ module.exports = ComponentWrapper;
 ComponentWrapper.__docgenInfo = {
   'description': 'Component for displaying a container that resembles the original CSS environment for different themes',
   'displayName': 'ComponentWrapper',
+  'methods': [],
   'props': {
     'theme': {
       'type': {

--- a/test/fixtures/example-module-exports/expected.js
+++ b/test/fixtures/example-module-exports/expected.js
@@ -43,7 +43,8 @@ function App() {
 module.exports = App;
 App.__docgenInfo = {
   'description': '',
-  'displayName': 'App'
+  'displayName': 'App',
+  'methods': []
 };
 
 if (typeof STORYBOOK_REACT_CLASSES !== 'undefined') {

--- a/test/fixtures/example/expected.js
+++ b/test/fixtures/example/expected.js
@@ -70,7 +70,8 @@ var App = function (_Component) {
 exports.default = App;
 App.__docgenInfo = {
   'description': '',
-  'displayName': 'App'
+  'displayName': 'App',
+  'methods': []
 };
 
 if (typeof STORYBOOK_REACT_CLASSES !== 'undefined') {

--- a/test/fixtures/flowType/actual.js
+++ b/test/fixtures/flowType/actual.js
@@ -9,6 +9,10 @@ type PropsType = {
 }
 
 class FlowTypeButton extends React.Component<PropsType> {
+  /**
+   * handle click number of times clicked and update parent component via callback
+   * @return  {string} returns nothing but at least this makes it into docgen
+   */
   handleClick = (bar?: string) => {
     console.log(bar);
   };

--- a/test/fixtures/flowType/expected.js
+++ b/test/fixtures/flowType/expected.js
@@ -36,6 +36,11 @@ var FlowTypeButton = function (_React$Component) {
       console.log(bar);
     }, _temp), _possibleConstructorReturn(_this, _ret);
   }
+  /**
+   * handle click number of times clicked and update parent component via callback
+   * @return  {string} returns nothing but at least this makes it into docgen
+   */
+
 
   _createClass(FlowTypeButton, [{
     key: 'render',
@@ -57,7 +62,7 @@ FlowTypeButton.__docgenInfo = {
   'displayName': 'FlowTypeButton',
   'methods': [{
     'name': 'handleClick',
-    'docblock': null,
+    'docblock': 'handle click number of times clicked and update parent component via callback\n@return  {string} returns nothing but at least this makes it into docgen',
     'modifiers': [],
     'params': [{
       'name': 'bar',
@@ -66,7 +71,13 @@ FlowTypeButton.__docgenInfo = {
         'name': 'string'
       }
     }],
-    'returns': null
+    'returns': {
+      'description': 'returns nothing but at least this makes it into docgen',
+      'type': {
+        'name': 'string'
+      }
+    },
+    'description': 'handle click number of times clicked and update parent component via callback'
   }],
   'props': {
     'label': {

--- a/test/fixtures/flowType/expected.js
+++ b/test/fixtures/flowType/expected.js
@@ -55,6 +55,19 @@ exports.default = FlowTypeButton;
 FlowTypeButton.__docgenInfo = {
   'description': '',
   'displayName': 'FlowTypeButton',
+  'methods': [{
+    'name': 'handleClick',
+    'docblock': null,
+    'modifiers': [],
+    'params': [{
+      'name': 'bar',
+      'optional': true,
+      'type': {
+        'name': 'string'
+      }
+    }],
+    'returns': null
+  }],
   'props': {
     'label': {
       'flowType': {

--- a/test/fixtures/functionDeclaration/expected.js
+++ b/test/fixtures/functionDeclaration/expected.js
@@ -37,6 +37,7 @@ exports.default = FuncDeclaration;
 FuncDeclaration.__docgenInfo = {
   'description': '',
   'displayName': 'FuncDeclaration',
+  'methods': [],
   'props': {
     'children': {
       'type': {

--- a/test/fixtures/hoc-multiple/expected.js
+++ b/test/fixtures/hoc-multiple/expected.js
@@ -49,6 +49,7 @@ exports.default = withHoc()(deeperHoc(Component));
 Component.__docgenInfo = {
   "description": "Super tiny component",
   "displayName": "Component",
+  "methods": [],
   "props": {
     "children": {
       "type": {

--- a/test/fixtures/hoc/expected.js
+++ b/test/fixtures/hoc/expected.js
@@ -49,6 +49,7 @@ exports.default = withHoc(Component);
 Component.__docgenInfo = {
   "description": "Super tiny component",
   "displayName": "Component",
+  "methods": [],
   "props": {
     "children": {
       "type": {

--- a/test/fixtures/multiple-exports/actual.js
+++ b/test/fixtures/multiple-exports/actual.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import './styles.css';
+
+class ErrorBox extends React.Component {
+  render() {
+    const { children } = this.props;
+
+    return (
+      <div className="error-box">
+        {children}
+      </div>
+    );
+  }
+}
+
+ErrorBox.propTypes = {
+  children: React.PropTypes.node.isRequired,
+};
+
+export default ErrorBox;
+
+class ErrorBox2 extends React.Component {
+  render() {
+    const { children2 } = this.props;
+
+    return (
+      <div className="error-box">
+        {children2}
+      </div>
+    );
+  }
+}
+
+ErrorBox2.propTypes = {
+  children2: React.PropTypes.node.isRequired,
+};
+
+export { ErrorBox2 };

--- a/test/fixtures/multiple-exports/expected.js
+++ b/test/fixtures/multiple-exports/expected.js
@@ -87,6 +87,7 @@ exports.ErrorBox2 = ErrorBox2;
 ErrorBox.__docgenInfo = {
   'description': '',
   'displayName': 'ErrorBox',
+  'methods': [],
   'props': {
     'children': {
       'type': {
@@ -109,6 +110,7 @@ if (typeof STORYBOOK_REACT_CLASSES !== 'undefined') {
 ErrorBox2.__docgenInfo = {
   'description': '',
   'displayName': 'ErrorBox2',
+  'methods': [],
   'props': {
     'children2': {
       'type': {

--- a/test/fixtures/multiple-exports/expected.js
+++ b/test/fixtures/multiple-exports/expected.js
@@ -1,0 +1,129 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.ErrorBox2 = undefined;
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+require('./styles.css');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var ErrorBox = function (_React$Component) {
+  _inherits(ErrorBox, _React$Component);
+
+  function ErrorBox() {
+    _classCallCheck(this, ErrorBox);
+
+    return _possibleConstructorReturn(this, (ErrorBox.__proto__ || Object.getPrototypeOf(ErrorBox)).apply(this, arguments));
+  }
+
+  _createClass(ErrorBox, [{
+    key: 'render',
+    value: function render() {
+      var children = this.props.children;
+
+
+      return _react2.default.createElement(
+        'div',
+        { className: 'error-box' },
+        children
+      );
+    }
+  }]);
+
+  return ErrorBox;
+}(_react2.default.Component);
+
+ErrorBox.propTypes = {
+  children: _react2.default.PropTypes.node.isRequired
+};
+
+exports.default = ErrorBox;
+
+var ErrorBox2 = function (_React$Component2) {
+  _inherits(ErrorBox2, _React$Component2);
+
+  function ErrorBox2() {
+    _classCallCheck(this, ErrorBox2);
+
+    return _possibleConstructorReturn(this, (ErrorBox2.__proto__ || Object.getPrototypeOf(ErrorBox2)).apply(this, arguments));
+  }
+
+  _createClass(ErrorBox2, [{
+    key: 'render',
+    value: function render() {
+      var children2 = this.props.children2;
+
+
+      return _react2.default.createElement(
+        'div',
+        { className: 'error-box' },
+        children2
+      );
+    }
+  }]);
+
+  return ErrorBox2;
+}(_react2.default.Component);
+
+ErrorBox2.propTypes = {
+  children2: _react2.default.PropTypes.node.isRequired
+};
+
+exports.ErrorBox2 = ErrorBox2;
+ErrorBox.__docgenInfo = {
+  'description': '',
+  'displayName': 'ErrorBox',
+  'props': {
+    'children': {
+      'type': {
+        'name': 'node'
+      },
+      'required': true,
+      'description': ''
+    }
+  }
+};
+
+if (typeof STORYBOOK_REACT_CLASSES !== 'undefined') {
+  STORYBOOK_REACT_CLASSES['test/fixtures/multiple-exports/actual.js'] = {
+    name: 'ErrorBox',
+    docgenInfo: ErrorBox.__docgenInfo,
+    path: 'test/fixtures/multiple-exports/actual.js'
+  };
+}
+
+ErrorBox2.__docgenInfo = {
+  'description': '',
+  'displayName': 'ErrorBox2',
+  'props': {
+    'children2': {
+      'type': {
+        'name': 'node'
+      },
+      'required': true,
+      'description': ''
+    }
+  }
+};
+
+if (typeof STORYBOOK_REACT_CLASSES !== 'undefined') {
+  STORYBOOK_REACT_CLASSES['test/fixtures/multiple-exports/actual.js'] = {
+    name: 'ErrorBox2',
+    docgenInfo: ErrorBox2.__docgenInfo,
+    path: 'test/fixtures/multiple-exports/actual.js'
+  };
+}

--- a/test/fixtures/reactCreateClass/expected.js
+++ b/test/fixtures/reactCreateClass/expected.js
@@ -41,6 +41,7 @@ var ComponentWrapper = React.createClass({
 module.exports = ComponentWrapper;
 ComponentWrapper.__docgenInfo = {
   'description': 'Component for displaying a container that resembles the original CSS environment for different themes',
+  'methods': [],
   'props': {
     'theme': {
       'type': {

--- a/test/fixtures/reactCreateElement/expected.js
+++ b/test/fixtures/reactCreateElement/expected.js
@@ -35,6 +35,7 @@ Kitten.defaultProps = {
 exports.default = Kitten;
 Kitten.__docgenInfo = {
   'description': '',
+  'methods': [],
   'props': {
     'isWide': {
       'type': {


### PR DESCRIPTION
There are some significant changes in how docgen works here:

Fix #40, fix #33 with a line from #38, change default to not remove method info

To fix the many tickets that came up for files that export more than one item, I switched over to use the `findAllExportedComponentDefinitions`. It required parsing a results array from `react-docgen` and taking a guess as to which component maps to which result array index if the result array item does not include a `displayName`.

There are also some pretty cool things we could do with the method information in the future so I changed the default to not remove those info.