### PR TITLE
Fix crash on name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,13 @@ function injectReactDocgenInfo(path, state, code, t) {
 
   docgenResults.forEach(function(docgenResult, index) {
     let exportName = docgenResult.actualName;
+
+    // If the result doesn't have an actualName,
+    // it's probably on arrow functions.
+    if (!exportName) {
+      return;
+    }
+
     const docNode = buildObjectExpression(docgenResult, t);
     const docgenInfo = t.expressionStatement(
       t.assignmentExpression(


### PR DESCRIPTION
Fixes #57

Hello,

It seems that components exported in arrow functions crash babel-plugin-react-docgen.
